### PR TITLE
Fixed an error with regards to the BlockBreakListener.

### DIFF
--- a/src/main/java/me/driftay/ctf/listeners/BlockBreakListener.java
+++ b/src/main/java/me/driftay/ctf/listeners/BlockBreakListener.java
@@ -1,12 +1,13 @@
 package me.driftay.ctf.listeners;
 
-import com.massivecraft.factions.util.XMaterial;
 import me.driftay.ctf.commands.CmdCTF;
 import me.driftay.ctf.manager.BlockManager;
 import me.driftay.ctf.manager.CTFRegion;
 import me.driftay.ctf.manager.Winner;
 import me.driftay.ctf.util.Message;
 import me.driftay.ctf.util.Utils;
+import me.driftay.ctf.util.XMaterial;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;


### PR DESCRIPTION
The problem was an incorrect import
Error Fixed:

[14:58:25 ERROR]: [Minecraft] Could not pass event BlockBreakEvent to SaberCTF v1.0-SNAPSHOT
org.bukkit.event.EventException
        at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:302) ~
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:78) ~
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62) ~
        at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.java:501) 
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:486) 
        at net.minecraft.server.v1_8_R3.PlayerInteractManager.breakBlock(PlayerInteractManager.java:286) 
        at net.minecraft.server.v1_8_R3.PlayerInteractManager.a(PlayerInteractManager.java:121) 
        at net.minecraft.server.v1_8_R3.PlayerConnection.a(PlayerConnection.java:630) 
        at net.minecraft.server.v1_8_R3.PacketPlayInBlockDig.a(SourceFile:40)
        at net.minecraft.server.v1_8_R3.PacketPlayInBlockDig.a(SourceFile:10)
        at net.minecraft.server.v1_8_R3.PlayerConnectionUtils$1.run(SourceFile:13) 
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_232]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_232]
        at net.minecraft.server.v1_8_R3.SystemUtils.a(SourceFile:44) 
        at net.minecraft.server.v1_8_R3.MinecraftServer.B(MinecraftServer.java:774) 
        at net.minecraft.server.v1_8_R3.DedicatedServer.B(DedicatedServer.java:378) 
        at net.minecraft.server.v1_8_R3.MinecraftServer.A(MinecraftServer.java:713) 
        at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:616) 
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_232]
Caused by: java.lang.NoSuchMethodError: com.massivecraft.factions.util.XMaterial.matchXMaterial(Ljava/lang/String;)Lcom/massivecraft/factions/util/XMaterial;
        at me.driftay.ctf.listeners.BlockBreakListener.onBreak(BlockBreakListener.java:31) ~[?:?]
        at sun.reflect.GeneratedMethodAccessor380.invoke(Unknown Source) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_232]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_232]
        at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:300) ~
        ... 18 more